### PR TITLE
Catch exceptions when querying linked notes on business accounts too

### DIFF
--- a/src/Evernote/Client.php
+++ b/src/Evernote/Client.php
@@ -327,7 +327,13 @@ class Client
                         if (null === $linkedNotebook->shareKey) {
                             continue;
                         }
-                        $resultNotebooks[] = $this->getNoteBookByLinkedNotebook($linkedNotebook);
+                        try {
+                            $resultNotebooks[] = $this->getNoteBookByLinkedNotebook($linkedNotebook);
+                        } catch (\Exception $e) {
+                            $e = ExceptionFactory::create($e);
+
+                            $this->logger->error('An error occured while fetching a linked notebook as a business user', array('exception' => $e, 'token' => $this->getToken()));
+                        }
                     }
                 }
 


### PR DESCRIPTION
This is a duplication of the error handling around `getNoteBookByLinkedNotebook()` right below this point, in the non-business account handling case. This was throwing uncaught exceptions, and I assume if this error handling is good enough for non-business accounts then it's good enough for business accounts?