### PR TITLE
Fixing issue with Undefined Index

### DIFF
--- a/src/Evernote/Client.php
+++ b/src/Evernote/Client.php
@@ -315,11 +315,11 @@ class Client
                 foreach ($linkedNotebooks as $linkedNotebook) {
                     if (array_key_exists($linkedNotebook->shareKey, $sharedBusinessNotebooks)) {
                         $sharedNotebook = $sharedBusinessNotebooks[$linkedNotebook->shareKey];
-                        $businessNotebook = $businessNotebooksGuids[$sharedNotebook->notebookGuid];
+                        $businessNotebook = $businessNotebooksGuids[$sharedNotebook->notebookGuid] ?? null;
 
                         $result = new Notebook($businessNotebook, $linkedNotebook, $sharedNotebook, $businessNotebook);
                         if ((array_key_exists($sharedNotebook->notebookGuid, $guidsCount) && $guidsCount[$sharedNotebook->notebookGuid] > 1)
-                            || $businessNotebook->businessNotebook !== null) {
+                            || ($businessNotebook && $businessNotebook->businessNotebook !== null)) {
                             $result->isShared = true;
                         }
                         $resultNotebooks[] = $result;


### PR DESCRIPTION
__METHOD__
I'm not really sure what caused this exactly, but an affected customer
had some notebooks being returned in linkedNotebooks and also business
shared notebooks but not business linked notebooks.

__EXPECTED__
The notebooks should still be returned.

__ACTUAL___
An undefined index error is coming up causing the script to just halt.

__CAUSE__
It's being assumed that if the linked notebook is in the shared business
notebooks, that it should also be in the linked business notebooks but
it's not for some unknown reason.

__FIX__
Since the item has been confirmed to have been shared because of the
shareKey comparison, making the business notebook item be null if the
linked business notebook entry is not found which will still have a
notebook instance which we can retrieve name and id information from.

Issue: Starfishco/api.raven.com#2103