### PR TITLE
Fixing uploadNote Method.

### DIFF
--- a/src/Evernote/Client.php
+++ b/src/Evernote/Client.php
@@ -471,6 +471,14 @@ class Client
             $uploaded_note = $this->getUserNotestore()->createNote($this->token, $edamNote);
             $noteStore     = $this->getUserNotestore();
             $token         = $this->token;
+        } catch(EDAMUserException $e) {
+            if (!$this->isBusinessUser()) {
+                throw $e;
+            }
+
+            $noteStore = $this->getBusinessNoteStore();
+            $token = $this->getBusinessToken();
+            $uploaded_note = $noteStore->createNote($token, $edamNote);
         } catch (EDAMNotFoundException $e) {
             $notebook = $this->getNotebook($notebook->guid, self::LINKED_SCOPE);
             if (null === $notebook) {


### PR DESCRIPTION
__METHOD__
Attempt to upload a note to a business notebook on some accounts.

__EXPECTED__
The note should be uploaded fine as long as the user has access.

__ACTUAL__
The attempt to create the note is throwing an EDAMUserException.

__CAUSE__
For some accounts, uploading a note to a business notebook throws an
EdamUserException and expects one to use the business notestore in order
to create a new note on the notebook.

__FIX__
Whenever an EDAMUserException is thrown, attempt to upload the note
using the business note store if the user is a business user, otherwise
just continue to throw the error.

Issue: StarfishCo/api.raven.com#2103